### PR TITLE
Configure remote backend for Terraform state with state locking via DocumentDB

### DIFF
--- a/.github/workflows/my_pipeline.yaml
+++ b/.github/workflows/my_pipeline.yaml
@@ -68,8 +68,8 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
-          git add terraform/terraform.tfstate terraform/.terraform.lock.hcl
-          git commit -m "Save Terraform state after ${{ github.event.inputs.terraform_action }}"
+          git add terraform/.terraform.lock.hcl
+          git commit -m "Save Terraform.lock.hcl after ${{ github.event.inputs.terraform_action }}"
           git push
 
  # ---------------------- Start Ansible Integration ---------------------------------------------- # 

--- a/.github/workflows/my_pipeline.yaml
+++ b/.github/workflows/my_pipeline.yaml
@@ -68,9 +68,9 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
-          git add terraform/.terraform.lock.hcl
-          git commit -m "Save Terraform.lock.hcl after ${{ github.event.inputs.terraform_action }}"
-          git push
+          git add terraform/.terraform.lock.hcl || true
+          git commit -m "Save Terraform.lock.hcl after ${{ github.event.inputs.terraform_action }}" || echo "No changes to commit
+          git push || echo "Nothing to push"
 
  # ---------------------- Start Ansible Integration ---------------------------------------------- # 
  

--- a/.github/workflows/my_pipeline.yaml
+++ b/.github/workflows/my_pipeline.yaml
@@ -69,7 +69,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           git add terraform/.terraform.lock.hcl || true
-          git commit -m "Save Terraform.lock.hcl after ${{ github.event.inputs.terraform_action }}" || echo "No changes to commit
+          git commit -m "Save Terraform.lock.hcl after ${{ github.event.inputs.terraform_action }}" || echo "No changes to commit"
           git push || echo "Nothing to push"
 
  # ---------------------- Start Ansible Integration ---------------------------------------------- # 

--- a/.github/workflows/my_pipeline.yaml
+++ b/.github/workflows/my_pipeline.yaml
@@ -110,6 +110,12 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/msd_assignment_key.pem
           chmod 600 ~/.ssh/msd_assignment_key.pem
+          
+      - name: Configure AWS credentials (Use Open ID Connect)
+        uses: aws-actions/configure-aws-credentials@v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/msd-tech-assignment-aws-role
+          aws-region: ap-south-1
 
       - name: Run Ansible Playbook - create inventories.ini file
         run: ansible-playbook ansible/main.yml --extra-vars "db_password=${{ secrets.DB_PASSWORD }}"

--- a/.github/workflows/my_pipeline.yaml
+++ b/.github/workflows/my_pipeline.yaml
@@ -83,11 +83,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Pull latest changes from main branch
-        run: |
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-          git pull origin main
+      # - name: Pull latest changes from main branch
+      #   run: |
+      #     git config --global user.email "actions@github.com"
+      #     git config --global user.name "GitHub Actions"
+      #     git pull origin main
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -33,5 +33,11 @@ jobs:
           sudo apt update
           sudo apt install -y ansible awscli
 
+      - name: Configure AWS credentials (Use Open ID Connect)
+        uses: aws-actions/configure-aws-credentials@v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/msd-tech-assignment-aws-role
+          aws-region: ap-south-1
+          
       - name: Run Ansible Playbook
         run: ansible-playbook ansible/demo.yml

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -10,7 +10,6 @@ on:
         type: choice
         options:
           - apply
-          - destroy
 
 permissions:
   id-token: write
@@ -24,22 +23,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12.3'
+      # - name: Set up Python
+      #   uses: actions/setup-python@v4
+      #   with:
+      #     python-version: '3.12.3'
           
       - name: Install Ansible
         run: |
           sudo apt update
-          sudo apt install -y ansible
-          sudo apt install -y python3-psycopg2
-          ansible-galaxy collection install community.postgresql
-          
-      - name: Install dependencies
-        run: |
-          /opt/hostedtoolcache/Python/3.12.3/x64/bin/pip install ansible psycopg2-binary
+          sudo apt install -y ansible awscli
 
-
-      - name: Run Ansible Playbook - create inventories.ini file
-        run: ansible-playbook ansible/demo.yml --extra-vars "db_password=${{ secrets.DB_PASSWORD }}"
+      - name: Run Ansible Playbook
+        run: ansible-playbook ansible/demo.yml

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -31,7 +31,14 @@ jobs:
       - name: Install Ansible
         run: |
           sudo apt update
-          sudo apt install -y ansible awscli
+          sudo apt install -y ansible
+          
+      - name: Install AWS CLI v2
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
+          aws --version
 
       - name: Configure AWS credentials (Use Open ID Connect)
         uses: aws-actions/configure-aws-credentials@v4.1.0

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -33,12 +33,15 @@ jobs:
           sudo apt update
           sudo apt install -y ansible
           
-      - name: Install AWS CLI v2
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
-          aws --version
+      # - name: Install AWS CLI v2
+      #   run: |
+      #     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+      #     unzip awscliv2.zip
+      #     sudo ./aws/install
+      #     aws --version
+
+      - name: Check AWS CLI Version
+        run: aws --version
 
       - name: Configure AWS credentials (Use Open ID Connect)
         uses: aws-actions/configure-aws-credentials@v4.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+terraform/.terraform/

--- a/ansible/configure_webservers.yml
+++ b/ansible/configure_webservers.yml
@@ -2,11 +2,13 @@
   hosts: webservers
   become: true
   vars:
-    tfstate_path: "../terraform/terraform.tfstate"
     db_name: mydb
     db_user: postgres
-    db_port: 5432
     #ansible_python_interpreter: /opt/hostedtoolcache/Python/3.12.3/x64/bin/python
+    bucket_name: msd-assignment-bucket
+    object_key: terraform.tfstate
+    region: ap-south-1
+    local_state_file: /tmp/terraform.tfstate
     
   tasks:
     - name: Install NGINX
@@ -27,10 +29,10 @@
 
     - name: Read terraform.tfstate
       slurp:
-        src: "{{ tfstate_path }}"
+        src: "{{ local_state_file }}"
       register: raw_tfstate
       delegate_to: localhost
-
+      
     - name: Parse tfstate JSON
       ansible.builtin.set_fact:
         tfstate: "{{ raw_tfstate.content | b64decode | from_json }}"
@@ -39,6 +41,7 @@
     - name: Extract postgres hostname
       set_fact:
         db_host: "{{ tfstate.outputs.postgres_endpoint.value.split(':')[0] }}"
+        db_port: "{{ tfstate.outputs.postgres_endpoint.value.split(':')[1] }}"
       delegate_to: localhost
       
     - name: Read content from PostgreSQL
@@ -121,7 +124,7 @@
           
           </body>
           </html>
-
+#############################################################################################################
     - name: Create nginx watchdog script
       copy:
         dest: /usr/local/bin/nginx_watchdog.sh

--- a/ansible/demo.yml
+++ b/ansible/demo.yml
@@ -8,6 +8,7 @@
     region: ap-south-1
     local_state_file: /tmp/terraform.tfstate
 
+
   tasks:
 
     - name: Ensure AWS CLI is installed
@@ -26,17 +27,16 @@
         --region {{ region }}
       register: s3_fetch_result
 
-    - name: Parse RDS endpoint from tfstate
-      command: >
-        jq -r '.resources[] 
-          | select(.type == "aws_db_instance" and .name == "postgres") 
-          | .instances[0].attributes.endpoint' {{ local_state_file }}
-      register: rds_endpoint
+
+    - name: Read terraform.tfstate
+      slurp:
+        src: "{{ local_state_file }}"
+      register: raw_tfstate
+
+    - name: Parse tfstate JSON
+      ansible.builtin.set_fact:
+        tfstate: "{{ raw_tfstate.content | b64decode | from_json }}"
 
     - name: Show RDS Endpoint
       debug:
-        msg: "RDS Endpoint is {{ rds_endpoint.stdout }}"
-
-    # Optional: set fact to use later
-    - set_fact:
-        db_host: "{{ rds_endpoint.stdout }}"
+        var: tfstate

--- a/ansible/demo.yml
+++ b/ansible/demo.yml
@@ -1,69 +1,42 @@
 ---
-- name: Create cars table and insert data into PostgreSQL
+- name: Fetch Terraform state file from S3
   hosts: localhost
   gather_facts: no
   vars:
-    db_host: "msd-assignment-db.c7ey8cm4mc17.ap-south-1.rds.amazonaws.com"
-    db_port: 5432
-    db_name: "mydb"
-    db_user: "postgres"
-    db_password: "gokulan123"
-    index_html_path: "/var/www/html/index.html"
-    ansible_python_interpreter: /opt/hostedtoolcache/Python/3.12.3/x64/bin/python
+    bucket_name: msd-assignment-bucket
+    object_key: terraform.tfstate
+    region: ap-south-1
+    local_state_file: /tmp/terraform.tfstate
 
   tasks:
-    - name: Create cars table
-      community.postgresql.postgresql_query:
-        db: "{{ db_name }}"
-        login_host: "{{ db_host }}"
-        login_user: "{{ db_user }}"
-        login_password: "{{ db_password }}"
-        port: "{{ db_port }}"
-        query: |
-          CREATE TABLE IF NOT EXISTS cars (
-              id SERIAL PRIMARY KEY,
-              brand TEXT,
-              model TEXT,
-              year INT
-          );
 
-    # - name: Insert car data
-    #   community.postgresql.postgresql_query:
-    #     db: "{{ db_name }}"
-    #     login_host: "{{ db_host }}"
-    #     login_user: "{{ db_user }}"
-    #     login_password: "{{ db_password }}"
-    #     port: "{{ db_port }}"
-    #     query: |
-    #       INSERT INTO cars (brand, model, year) VALUES
-    #       ('Toyota', 'Corolla', 2020),
-    #       ('Honda', 'Civic', 2019),
-    #       ('Ford', 'Mustang', 2021);
+    - name: Ensure AWS CLI is installed
+      command: aws --version
+      register: aws_cli_check
+      ignore_errors: yes
 
+    - name: Fail if AWS CLI is not installed
+      fail:
+        msg: "AWS CLI is not installed!"
+      when: aws_cli_check.rc != 0
 
-    # - name: Read content from PostgreSQL
-    #   community.postgresql.postgresql_query:
-    #     db: "{{ db_name }}"
-    #     login_host: "{{ db_host }}"
-    #     login_user: "{{ db_user }}"
-    #     login_password: "{{ db_password }}"
-    #     port: "{{ db_port }}"
-    #     query: "SELECT * FROM cars;"
-    #   register: query_result
+    - name: Download Terraform state file from S3
+      command: >
+        aws s3 cp s3://{{ bucket_name }}/{{ object_key }} {{ local_state_file }}
+        --region {{ region }}
+      register: s3_fetch_result
 
-    # - name: Show query results for debugging (optional)
-    #   debug:
-    #     var: query_result
+    - name: Parse RDS endpoint from tfstate
+      command: >
+        jq -r '.resources[] 
+          | select(.type == "aws_db_instance" and .name == "postgres") 
+          | .instances[0].attributes.endpoint' {{ local_state_file }}
+      register: rds_endpoint
 
-    - name: Append content to index.html
-      copy:
-        content: |
-          {% for row in query_result.query_result %}
-          <p>{{ row.content }}</p>
-          {% endfor %}
-        dest: "{{ index_html_path }}"
-        owner: www-data
-        group: www-data
-        mode: '0644'
-        force: no
-      when: query_result.query_result is defined
+    - name: Show RDS Endpoint
+      debug:
+        msg: "RDS Endpoint is {{ rds_endpoint.stdout }}"
+
+    # Optional: set fact to use later
+    - set_fact:
+        db_host: "{{ rds_endpoint.stdout }}"

--- a/ansible/inventories.ini
+++ b/ansible/inventories.ini
@@ -1,3 +1,3 @@
 [webservers]
-UbuntuWebServer1 ansible_host=43.205.136.96 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o StrictHostKeyChecking=no'
-UbuntuWebServer2 ansible_host=13.204.64.233 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+UbuntuWebServer1 ansible_host=13.235.245.56 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+UbuntuWebServer2 ansible_host=13.127.138.236 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -3,12 +3,15 @@
   gather_facts: false
 
   vars:
-    tfstate_path: "../terraform/terraform.tfstate"
     inventory_path: "./inventories.ini"
     db_name: mydb
     db_user: postgres
-    db_port: 5432
     ansible_python_interpreter: /opt/hostedtoolcache/Python/3.12.3/x64/bin/python
+    bucket_name: msd-assignment-bucket
+    object_key: terraform.tfstate
+    region: ap-south-1
+    local_state_file: /tmp/terraform.tfstate
+    
     
 
   tasks:
@@ -17,9 +20,15 @@
         path: "{{ inventory_path }}"
         state: absent
 
+    - name: Download Terraform state file from S3
+      command: >
+        aws s3 cp s3://{{ bucket_name }}/{{ object_key }} {{ local_state_file }}
+        --region {{ region }}
+      register: s3_fetch_result
+
     - name: Read terraform.tfstate
       slurp:
-        src: "{{ tfstate_path }}"
+        src: "{{ local_state_file }}"
       register: raw_tfstate
 
     - name: Parse tfstate JSON
@@ -49,7 +58,8 @@
     - name: Extract postgres hostname
       set_fact:
         db_host: "{{ tfstate.outputs.postgres_endpoint.value.split(':')[0] }}"
-       
+        db_port: "{{ tfstate.outputs.postgres_endpoint.value.split(':')[1] }}"
+        
     - name: Create cars table
       community.postgresql.postgresql_query:
         db: "{{ db_name }}"
@@ -67,7 +77,6 @@
       no_log: true
 
     - name: Insert car data
-      #no_log: true
       community.postgresql.postgresql_query:
         db: "{{ db_name }}"
         login_host: "{{ db_host }}"
@@ -79,4 +88,4 @@
           ('Toyota', 'Corolla', 2020),
           ('Honda', 'Civic', 2019),
           ('Ford', 'Mustang', 2021);
-
+      no_log: true    

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "msd-assignment-bucket"
+    key            = "terraform.tfstate"
+    region         = "ap-south-1"
+    encrypt        = true             # Enable encryption at rest
+    dynamodb_table = "msd-assignment-table"
+  }
+}


### PR DESCRIPTION
### 📌 Summary

This PR adds a `backend.tf` file to configure a remote backend for storing the Terraform state file and enabling state locking using AWS DocumentDB. 

### ✅ What’s Included
- Added `backend.tf` to store Terraform state in an S3 bucket.
- Enabled state locking and consistency checks using a DynamoDB table (or DocumentDB, depending on your implementation).
- Ensures safe and collaborative Terraform usage across environments.

### 🔍 Why This Change
- Avoids local state file conflicts.
- Enables team collaboration on infrastructure.
- Protects against simultaneous `terraform apply` executions through state locking.

### 🔄 How to Use
Before running Terraform:
1. Ensure the S3 bucket and DocumentDB (or DynamoDB) backend components exist.
2. Run `terraform init` to initialize the backend.

### ⚠️ Notes
- Make sure AWS credentials with access to the backend are available in your environment.
- Do **not** commit `terraform.tfstate` or `.terraform/` directories.
